### PR TITLE
Fix Rows all by default

### DIFF
--- a/lib/opsview_rest.rb
+++ b/lib/opsview_rest.rb
@@ -98,7 +98,7 @@ class OpsviewRest
     }.update options
 
     if options[:name].nil?
-      raise "Need to specify the name of the object."
+      raise ArgumentError, "Need to specify the name of the object."
     else
       get("config/#{options[:type]}?s.name=#{options[:name]}?rows=#{options[:rows]}")
     end
@@ -111,7 +111,7 @@ class OpsviewRest
     }.update options
 
     if options[:name].nil?
-      raise "Need to specify the name of the object."
+      raise ArgumentError, "Need to specify the name of the object."
     else
       id = find(:type => options[:type], :name => options[:name])[0]["id"]
       delete("config/#{options[:type]}/#{id}")

--- a/spec/opsview_rest_spec.rb
+++ b/spec/opsview_rest_spec.rb
@@ -64,4 +64,16 @@ describe OpsviewRest do
     end
   end
 
+  describe '#find' do
+    it 'returns an error if name is nil' do
+      expect {opsview_rest.find}.to raise_error ArgumentError, "Need to specify the name of the object."
+    end
+  end
+
+  describe '#purge' do
+    it 'returns an error if name is nil' do
+      expect {opsview_rest.purge}.to raise_error ArgumentError, "Need to specify the name of the object."
+    end
+  end
+
 end


### PR DESCRIPTION
So, it turns out the rows parameter doesn't work as a header, you have to do it as a URI parameter.

So I've changed the rows to use 'all' by default.

Also, fixed a bug with the `unless name` bit. Currently this will not work:

``` ruby
puts connection.find(:type => 'host', :name => 'foo')
```

```
/Users/peters/projects/opsview_rest/lib/opsview_rest.rb:98:in `find': undefined local variable or method `name' for #<OpsviewRest:0x007ff2926176c8> (NameError)
    from pkg/test.rb:5:in `<main>'
```

So fixed that as well :+1:
