### PR TITLE
Add allow failure for 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - ruby-head
@@ -8,3 +7,4 @@ script: bundle exec rake
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 1.8.7


### PR DESCRIPTION
`Gem::InstallError: mime-types requires Ruby version >= 1.9.2.`
