### PR TITLE
Up the JSON version for the gem and a couple bugfixes

### DIFF
--- a/lib/opsview_rest.rb
+++ b/lib/opsview_rest.rb
@@ -143,7 +143,7 @@ class OpsviewRest
       response = block.call
       response.body
     rescue RestClient::Exception => e
-      puts "I have #{e.inspect} with #{e.http_code}"
+      raise "I have #{e.inspect} with #{e.http_code}"
       if e.http_code == 307
         get(e.response)
       end

--- a/lib/opsview_rest.rb
+++ b/lib/opsview_rest.rb
@@ -96,15 +96,19 @@ class OpsviewRest
 
   def find(options = {})
     options = {
-      :type => "host",
+      :type => nil,
       :rows => "all",
-      :name => nil
+      :searchattribute => nil
     }.update options
 
+    if options[:searchattribute].nil?
+      options[:searchattribute] = "name"
+    end
+    
     if options[:name].nil?
       raise ArgumentError, "Need to specify the name of the object."
     else
-      get("config/#{options[:type]}?s.name=#{options[:name]}&rows=#{options[:rows]}")
+      get("config/#{options[:type]}?s.#{options[:searchattribute]}=#{options[:name]}&rows=#{options[:rows]}")
     end
   end
 

--- a/lib/opsview_rest/hostcheckcommand.rb
+++ b/lib/opsview_rest/hostcheckcommand.rb
@@ -22,7 +22,6 @@ class OpsviewRest
       @resource_type = @options[:type]
 
       @options[:plugin] = { "name" => @options[:plugin] }
-      @options[:hosts] = @options[:hosts].map { |x| { "name" => x } }
       @options[:uncommitted] = if @options[:uncommitted] then 1 else 0 end
 
       save(@options[:replace]) if @options[:save]

--- a/opsview_rest.gemspec
+++ b/opsview_rest.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "yard", "~> 0.8.7.3"
   gem.add_development_dependency "webmock", "~> 1.11.0"
 
-  gem.add_dependency 'json', '~> 1.6.1'
+  gem.add_dependency 'json'
   gem.add_dependency 'rest-client', '~> 1.6.6'
 
-  gem.version = '0.4.0'
+  gem.version = '0.4.1'
 end

--- a/opsview_rest.gemspec
+++ b/opsview_rest.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json'
   gem.add_dependency 'rest-client', '~> 1.6.6'
 
-  gem.version = '0.4.2'
+  gem.version = '0.4.3'
 end

--- a/opsview_rest.gemspec
+++ b/opsview_rest.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "yard", "~> 0.8.7.3"
   gem.add_development_dependency "webmock", "~> 1.11.0"
 
-  gem.add_dependency 'json'
+  gem.add_dependency 'json', '~> 1.7.7'
   gem.add_dependency 'rest-client', '~> 1.6.6'
 
   gem.version = '0.4.3'

--- a/opsview_rest.gemspec
+++ b/opsview_rest.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json'
   gem.add_dependency 'rest-client', '~> 1.6.6'
 
-  gem.version = '0.4.1'
+  gem.version = '0.4.2'
 end


### PR DESCRIPTION
Hi,
I'm finally getting back to this. Locked the JSON version back down to 1.7.7, which seems to work great both on my local OSX environment and on various AWS hosts.

I've made a couple small bug fixes as well, that were causing errors in our environment. 

This gem has been super useful for us by the way. We use it to actually make OpsView useful in a very dynamic AWS environment, with hundreds of hosts coming and going on a daily basis. 