### PR TITLE
A few more bugfixes and some nil guarding

### DIFF
--- a/lib/opsview_rest.rb
+++ b/lib/opsview_rest.rb
@@ -57,8 +57,8 @@ class OpsviewRest
     when :monitoring_server
       require 'opsview_rest/monitoring_server'
       OpsviewRest::MonitoringServer.new(self, options)
-    when :notification_method
-      require 'opsview_rest/notification_method'
+    when :notificationmethod
+      require 'opsview_rest/notificationmethod'
       OpsviewRest::NotificationMethod.new(self, options)
     when :role
       require 'opsview_rest/role'

--- a/lib/opsview_rest/contact.rb
+++ b/lib/opsview_rest/contact.rb
@@ -59,9 +59,9 @@ class OpsviewRest
 
       @options[:all_servicegroups] = if @options[:all_servicegroups] then 1 else 0 end
       @options[:all_hostgroups] = if @options[:all_hostgroups] then 1 else 0 end
-      @options[:servicegroups] = @options[:servicegroups].map { |x| { "name" => x } }
-      @options[:keywords] = @options[:keywords].map { |x| { "name" => x } }
-      @options[:hostgroups] = @options[:hostgroups].map { |x| { "name" => x } }
+      @options[:servicegroups] = @options[:servicegroups].map { |x| { "name" => x } } unless @options[:servicegroups].nil?
+      @options[:keywords] = @options[:keywords].map { |x| { "name" => x } } unless @options[:keywords].nil?
+      @options[:hostgroups] = @options[:hostgroups].map { |x| { "name" => x } } unless @options[:hostgroups].nil?
       @options[:role] = { "name" => @options[:role] }
 
       save(@options[:replace]) if @options[:save]

--- a/lib/opsview_rest/notificationmethod.rb
+++ b/lib/opsview_rest/notificationmethod.rb
@@ -13,7 +13,7 @@ class OpsviewRest
         :master => false,
         :active => true,
         :command => "notify_by_email",
-        :contact_variables => "EMAIL"
+        :contact_variables => "EMAIL",
         :save    => true,
         :replace => false
       }.update options

--- a/lib/opsview_rest/timeperiod.rb
+++ b/lib/opsview_rest/timeperiod.rb
@@ -29,10 +29,10 @@ class OpsviewRest
       @opsview = opsview
       @resource_type = @options[:type]
 
-      @option[:servicecheck_notification_periods] = @option[:servicecheck_notification_periods].map { |x| { "name" => x } }
-      @option[:servicecheck_check_periods] = @option[:servicecheck_check_periods].map { |x| { "name" => x } }
-      @option[:host_check_periods] = @option[:host_check_periods].map { |x| { "name" => x } }
-      @option[:host_notification_periods] = @option[:host_notification_periods].map { |x| { "name" => x } }
+      @options[:servicecheck_notification_periods] = @options[:servicecheck_notification_periods].map { |x| { "name" => x } } unless @options[:servicecheck_notification_periods].nil?
+      @options[:servicecheck_check_periods] = @options[:servicecheck_check_periods].map { |x| { "name" => x } } unless  @options[:servicecheck_check_periods].nil?
+      @options[:host_check_periods] = @options[:host_check_periods].map { |x| { "name" => x } } unless @options[:host_check_periods].nil?
+      @options[:host_notification_periods] = @options[:host_notification_periods].map { |x| { "name" => x } } unless @options[:host_notification_periods].nil?
 
       save(@options[:replace]) if @options[:save]
     end


### PR DESCRIPTION
Happy holidays!

I've noticed and fixed a couple more bugs while expanding our OpsView automation to control notification methods. 

The nil guarding is probably a good idea across the board, and I'll can add it if I have some more time, but these are the couple spots I happened to catch. It works fine most of the time, but the problems happen when trying to import the configs exported from OpsView back into OpsView, since OpsView exports an object even if it's empty.

Thanks!