### PR TITLE
Upgrade json to work on Ruby 2.2

### DIFF
--- a/opsview_rest.gemspec
+++ b/opsview_rest.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "yard", "~> 0.8.7.3"
   gem.add_development_dependency "webmock", "~> 1.11.0"
 
-  gem.add_dependency 'json', '~> 1.7.7'
+  gem.add_dependency 'json', '~> 1.8'
   gem.add_dependency 'rest-client', '~> 1.6.6'
 
   gem.version = '0.4.4'


### PR DESCRIPTION
Upgrading json to 1.8 appears to resolve issue #12

I get 8 tests passing and 1 pending and a quick run of listing hosts seems to work against Opsview Core 3.20.
